### PR TITLE
Fix typo in WhatsApp contact link

### DIFF
--- a/src/evento.html
+++ b/src/evento.html
@@ -147,7 +147,7 @@
                         target="_blank">artur.duarte@estudante.ifgoiano.edu.br</a>
                 </li>
                 <li>Telefone: <a
-                        href="https://wa.me//64992869883?text=Olá, gostaria de pedir mais informaçoes sobre o evento musical."
+                        href="https://wa.me//64992869883?text=Olá, gostaria de pedir mais informações sobre o evento musical."
                         target="_blank">(64) 99286-9883</a></li>
                 <li>Instagram: <a href=" https://www.instagram.com/arturduartemonteiro/"
                         target="_blank">@arturduartemonteiro</a>


### PR DESCRIPTION
## Summary
- correct the spelling of "informações" in `evento.html`

## Testing
- `grep -n "informações" src/evento.html`

------
https://chatgpt.com/codex/tasks/task_e_684027d839dc832aa8cfded2d981bed3