### PR TITLE
Fix README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,13 @@ Abra o terminal e execute:
 ```bash
 git clone https://github.com/seu-usuario/seu-repositorio.git
 cd seu-repositorio
+```
+
+### Passo 2: Abra no Navegador
+Abra o arquivo `index.html` diretamente ou utilize um servidor local:
+```bash
+python3 -m http.server
+```
+
+### Uso
+Acesse `http://localhost:8000` (ou apenas abra `index.html`) para explorar o site.


### PR DESCRIPTION
## Summary
- close unclosed code block in README
- add instructions for opening the project and basic usage notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d2563708832aa54df66438565de2