### PR TITLE
Use external script for mobile menu

### DIFF
--- a/JavaScript/index.js
+++ b/JavaScript/index.js
@@ -1,58 +1,68 @@
-// Menu hamburguer
-const toggleButton = document.getElementById('button-toggle');
-const navLinks = document.querySelector('.nav-links');
+document.addEventListener('DOMContentLoaded', () => {
+    // Menu hamburguer
+    const toggleButton = document.getElementById('button-toggle');
+    const navLinks = document.querySelector('.nav-links');
 
-toggleButton.addEventListener('click', () => {
-    navLinks.classList.toggle('active');
-});
-
-// Scroll suave
-document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-    anchor.addEventListener('click', function (e) {
-        e.preventDefault();
-        const target = document.querySelector(this.getAttribute('href'));
-        if (target) {
-            target.scrollIntoView({
-                behavior: 'smooth',
-                block: 'start'
-            });
-        }
-    });
-});
-
-// Animação de entrada
-const fadeElements = document.querySelectorAll('.fade-in');
-
-const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-        if (entry.isIntersecting) {
-            entry.target.classList.add('show');
-        }
-    });
-}, { threshold: 0.1 });
-
-fadeElements.forEach(element => observer.observe(element));
-
-// Botão voltar ao topo
-const backToTopButton = document.getElementById('backToTop');
-
-window.addEventListener('scroll', () => {
-    if (window.scrollY > 300) {
-        backToTopButton.style.display = 'block';
-    } else {
-        backToTopButton.style.display = 'none';
+    if (toggleButton && navLinks) {
+        toggleButton.addEventListener('click', () => {
+            navLinks.style.display = navLinks.style.display === 'flex' ? 'none' : 'flex';
+        });
     }
-});
 
-backToTopButton.addEventListener('click', () => {
-    window.scrollTo({
-        top: 0,
-        behavior: 'smooth'
+    // Scroll suave
+    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+        anchor.addEventListener('click', function (e) {
+            e.preventDefault();
+            const target = document.querySelector(this.getAttribute('href'));
+            if (target) {
+                target.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'start'
+                });
+            }
+        });
     });
-});
 
-// Tema claro/escuro
-const themeButton = document.getElementById('toggleTheme');
-themeButton.addEventListener('click', () => {
-    document.body.classList.toggle('light-theme');
+    // Animação de entrada
+    const fadeElements = document.querySelectorAll('.fade-in');
+
+    if (fadeElements.length) {
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('show');
+                }
+            });
+        }, { threshold: 0.1 });
+
+        fadeElements.forEach(element => observer.observe(element));
+    }
+
+    // Botão voltar ao topo
+    const backToTopButton = document.getElementById('backToTop');
+
+    if (backToTopButton) {
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 300) {
+                backToTopButton.style.display = 'block';
+            } else {
+                backToTopButton.style.display = 'none';
+            }
+        });
+
+        backToTopButton.addEventListener('click', () => {
+            window.scrollTo({
+                top: 0,
+                behavior: 'smooth'
+            });
+        });
+    }
+
+    // Tema claro/escuro
+    const themeButton = document.getElementById('toggleTheme');
+    if (themeButton) {
+        themeButton.addEventListener('click', () => {
+            document.body.classList.toggle('light-theme');
+        });
+    }
 });

--- a/index.html
+++ b/index.html
@@ -167,18 +167,7 @@
         <p>"Dizem que beleza cansa, mas estou sempre cansado e nada belo." - Artur, 2023</p>
     </footer>
 
-    <script>// Menu hamburguer
-        document.addEventListener('DOMContentLoaded', () => {
-            const toggleButton = document.getElementById('button-toggle');
-            const navLinks = document.querySelector('.nav-links');
-
-            toggleButton.addEventListener('click', () => {
-                navLinks.style.display = navLinks.style.display === 'flex' ? 'none' : 'flex';
-            });
-        });
-
-
-    </script>
+    <script src="JavaScript/index.js"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- load `index.js` in the home page
- handle menu toggle inside `index.js`
- protect other handlers behind element checks

## Testing
- `npm test` *(fails: no `package.json` found)*

------
https://chatgpt.com/codex/tasks/task_e_68471addfb7c832abcf93aeb7655fba5